### PR TITLE
Thrust Control System Bypass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ catkin_ws/.catkin_workspace
 *.pyc
 
 *.vscode
+.idea/
+venv/
 
 .bash_history
 .cache

--- a/path_planning/src/path_planning/ros_modules.py
+++ b/path_planning/src/path_planning/ros_modules.py
@@ -8,9 +8,9 @@ from std_srvs.srv import Trigger, TriggerRequest
 from geometry_msgs.msg import Vector3, Wrench
 from sensor_msgs.msg import Image
 
-import data_structures  as DS
+import data_structures as DS
 
-from aquadrone_msgs.msg import SubState
+from aquadrone_msgs.msg import SubState, MotorControls
 
 
 class ROSControlsModule:
@@ -18,6 +18,7 @@ class ROSControlsModule:
         self.depth_pub = rospy.Publisher("/depth_control/goal_depth", Float64, queue_size=1)
         self.yaw_pub = rospy.Publisher("orientation_target", Vector3, queue_size=1)
         self.planar_move_pub = rospy.Publisher("/movement_command", Wrench, queue_size=1)
+        self.motor_command_pub = rospy.Publisher("motor_command", MotorControls, queue_size=0)
 
     def set_depth_goal(self, d):
         self.depth_pub.publish(d)
@@ -38,6 +39,17 @@ class ROSControlsModule:
         w.torque.y = 0
         w.torque.z = Tz
         self.planar_move_pub.publish(w)
+
+    def send_direct_motor_thrusts(self, thrusts):
+        """
+        This command will only work if the control launch file is given an argument of control_loop=False.
+        If you want to use this, then you should have the sim_control launch file as a child of your launch file
+        and pass it the parameter control_loop="False".
+        :param thrusts: Array of 8 floats for the 8 motors.
+        """
+        msg = MotorControls()
+        msg.motorThrusts = thrusts
+        self.motor_command_pub.publish(msg)
 
 
 class ROSStateEstimationModule:

--- a/thruster_control/launch/sim_control.launch
+++ b/thruster_control/launch/sim_control.launch
@@ -2,6 +2,7 @@
     <arg name="model"/>
 
     <param name="model" value="$(arg model)"/>
+    <param name="control_loop" value="$(arg control_loop)"/>
 
     <node name="thruster_controller" pkg="thruster_control" type="sim_thruster_controller.py" output="screen"/>
     <node name="depth_pid" pkg="thruster_control" type="demo_depth_control.py" output="screen"/>

--- a/thruster_control/nodes/sim_thruster_controller.py
+++ b/thruster_control/nodes/sim_thruster_controller.py
@@ -39,6 +39,6 @@ if __name__ == "__main__":
     th_spec.initialize()
     specs = [th_spec for i in range(0, num)]
 
-    stc = SimThrusterController(config, mcc, interface, specs)
+    do_control_loop = rospy.get_param("control_loop", True)
+    stc = SimThrusterController(config, mcc, interface, specs, do_control_loop=do_control_loop)
     stc.run()
-   


### PR DESCRIPTION
Allows turning off the control loop in the thrust controller. In this case, only direct commands to the individual motors will be used. This is used to add a new option to directly send thrust commands in ros_modules.py